### PR TITLE
fix: add source_channel tracking to all Bailian links + API Key direct links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Node.js](https://img.shields.io/badge/node-%3E%3D18-brightgreen)](https://nodejs.org)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 
-[Aliyun Model Studio CLI Site](https://bailian.console.aliyun.com/cli?source_channel=cli_github&) · [中文](./README.zh.md) · [API Documentation](https://help.aliyun.com/zh/model-studio/) · [Get API Key](https://bailian.console.aliyun.com/cli?source_channel=key_github&)
+[Aliyun Model Studio CLI Site](https://bailian.console.aliyun.com/cli?source_channel=cli_github&) · [中文](./README.zh.md) · [API Documentation](https://help.aliyun.com/zh/model-studio/) · [Get API Key](https://bailian.console.aliyun.com/cn-beijing/?source_channel=key_github&tab=app#/api-key)
 
 ---
 
@@ -29,6 +29,12 @@ Each skill is an independent, composable workflow unit. The 3rd-party set spans 
 ---
 
 ## Quick Start
+
+### Prerequisites
+
+You need an **Aliyun Model Studio API Key** to run any skill that calls `bl` commands.
+
+👉 [Get your free API Key](https://bailian.console.aliyun.com/cn-beijing/?source_channel=key_github&tab=app#/api-key)
 
 ### Manual Install
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -8,7 +8,7 @@
 [![Node.js](https://img.shields.io/badge/node-%3E%3D18-brightgreen)](https://nodejs.org)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 
-[阿里云百炼 CLI 官方主页](https://bailian.console.aliyun.com/cli?source_channel=cli_github&) · [English](./README.md) · [API 文档](https://help.aliyun.com/zh/model-studio/) · [获取 API Key](https://bailian.console.aliyun.com/cli?source_channel=key_github&)
+[阿里云百炼 CLI 官方主页](https://bailian.console.aliyun.com/cli?source_channel=cli_github&) · [English](./README.md) · [API 文档](https://help.aliyun.com/zh/model-studio/) · [获取 API Key](https://bailian.console.aliyun.com/cn-beijing/?source_channel=key_github&tab=app#/api-key)
 
 ---
 
@@ -29,6 +29,12 @@ ModelStudio Skills 是阿里云百炼（ModelStudio）推出的官方 AI Agent �
 ---
 
 ## 快速开始
+
+### 前置条件
+
+运行调用 `bl` 命令的技能需要一个**阿里云百炼 API Key**。
+
+👉 [免费获取 API Key](https://bailian.console.aliyun.com/cn-beijing/?source_channel=key_github&tab=app#/api-key)
 
 ### 手动安装
 

--- a/skills/bailian-docs-llm-wiki/README.md
+++ b/skills/bailian-docs-llm-wiki/README.md
@@ -48,15 +48,20 @@ This skill provides a structured, offline-first knowledge base that your agent r
 
 ## Prerequisites
 
-This skill requires Alibaba Cloud Model Studio CLI (`bl`). Before using this skill, check if `bl` is installed:
+This skill requires Alibaba Cloud Model Studio CLI (`bl`) and a valid API Key.
+
+1. **Get your API Key:** [Aliyun Model Studio Console](https://bailian.console.aliyun.com/cn-beijing/?source_channel=key_github&tab=app#/api-key)
+2. **Install CLI:** [Install Guide](https://bailian.console.aliyun.com/cli?source_channel=cli_github&) or run `npm install -g bailian-cli`
+3. **Authenticate:**
+   ```bash
+   bl auth login --api-key sk-xxxxx
+   ```
+
+Verify installation:
 
 ```bash
 bl --version
 ```
-
-If not installed or the command is not found, follow the install guide:
-
-> https://bailian.aliyun.com/cli/install.md
 
 ## License
 

--- a/skills/spark-video/README.md
+++ b/skills/spark-video/README.md
@@ -191,7 +191,8 @@ it'll run the right command.
 - After install the agent doesn't recognize `spark-video` → restart the
   agent / open a new session
 - `bl: command not found` → `npm install -g bailian-cli && npx skills add modelstudioai/cli --all -g && npx skills add modelstudioai/skills --all -g && bl auth login`
-  (full install guide: <https://bailian.aliyun.com/cli/install.md>)
+  (full install guide: <https://bailian.console.aliyun.com/cli?source_channel=cli_github&>)
+- **Need an API Key?** → [Get your free API Key](https://bailian.console.aliyun.com/cn-beijing/?source_channel=key_github&tab=app#/api-key), then `bl auth login --api-key sk-xxxxx`
 - `Permission denied: scripts/bl` → `chmod +x scripts/*.sh scripts/bl`
 - Render seems stuck → `tail -f projects/<p>/<e>/logs/model_calls.jsonl | jq .`
 


### PR DESCRIPTION
## Summary

- Replace API Key link from `/cli?source_channel=key_github&` to `/cn-beijing/?source_channel=key_github&tab=app#/api-key` (direct to key management page)
- Add Prerequisites section in Quick Start (EN + CN) with API Key link
- Add API Key + CLI links to `bailian-docs-llm-wiki` Prerequisites
- Add API Key link to `spark-video` Troubleshooting

## Changed files

- `README.md` — top nav link + new Prerequisites subsection
- `README.zh.md` — same in Chinese
- `skills/bailian-docs-llm-wiki/README.md` — rewritten Prerequisites with API Key, CLI, and auth steps
- `skills/spark-video/README.md` — added API Key bullet to Troubleshooting + updated install guide link