### PR TITLE
docs: add Full Tutorial link to GitHub Pages (EN+CN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ The table below is an index of **curated community** projects verified by the Ba
 
 This repository's code is released under the [Apache-2.0](./LICENSE) license.
 
+## 📖 Full Tutorial
+
+Step-by-step setup, hands-on walkthroughs, and end-to-end examples are on our docs site:
+
+**[modelstudioai.github.io/guide/](https://modelstudioai.github.io/guide/)**
+
 ---
 
 > **Disclaimer** — These skills instruct your Agent to call DashScope / Bailian APIs via `bl` on your behalf, billed to your Alibaba Cloud account. Generated content may be inaccurate — review before use. Keep your API key secure. This project is provided as-is, without warranties.

--- a/README.zh.md
+++ b/README.zh.md
@@ -109,6 +109,12 @@ npx skills add modelstudioai/skills
 
 本仓库代码以 [Apache-2.0](./LICENSE) 协议发布。
 
+## 📖 完整教程
+
+从注册到实战、Skill 加载、跨 AI Agent 框架使用，完整的中文教程在文档站：
+
+**[modelstudioai.github.io/guide/](https://modelstudioai.github.io/guide/)**
+
 ---
 
 > **免责声明** — 本仓库技能会指导 Agent 通过 `bl` 代你调用 DashScope / 百炼 API，费用由你的阿里云账号承担。生成内容可能不准确，使用前请自行核对。请妥善保管 API Key。本项目按「现状」提供，不作任何担保。


### PR DESCRIPTION
Adds a `📖 Full Tutorial / 完整教程` section to README.md and README.zh.md, pointing to https://modelstudioai.github.io/guide/