### PR TITLE
docs(readme): list all first-party skills in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ These skills ship with this repository and are maintained by the ModelStudio tea
 | Skill | What it does |
 |-------|----------------|
 | [`bailian-docs-llm-wiki`](./skills/bailian-docs-llm-wiki/) | Routes the Agent through the in-repo **Bailian docs library** for model specs and pricing, API/error codes, agents/RAG/knowledge base, SDKs and multimodal, billing, etc. Start from `models/index.md` and `wiki/index.md`, then drill down. |
+| [`bailian-model-recommend`](./skills/bailian-model-recommend/) | **Model selection & recommendation**: given a scenario or feature need, picks the best-fit Bailian model and hands back ready-to-run sample code. Activates on "recommend / which model / compare." Reads the `models/` data from `bailian-docs-llm-wiki`. |
+| [`financial-expert`](./skills/financial-expert/) | **Financial data analysis** over China A-shares, funds, and bonds via `bl mcp` (`market-cmapi00073529`): stock/fund/fund-manager screening, financials (net profit / revenue / ROE), macro & industry time series (GDP / CPI), broker research reports, and listed-company filings. |
+| [`happyhorse-prompt-studio`](./skills/happyhorse-prompt-studio/) | **Interactive prompt studio for HappyHorse 1.0 video**: guides scenario discovery with vivid examples, then assembles production-ready prompts in JP/CN/EN. Covers manga drama, character PV, manga motion, virtual idol MV, and free-form scenarios. |
 | [`spark-video`](./skills/spark-video/) | **End-to-end short-film production**: screenwriter ↔ director (per scene) → parallel render DAG → per-clip QA → stitch. Best for “make me an episode / a product ad in one go.” The entry skill registers as **`spark-video-episode`** (see [`SKILL.md`](./skills/spark-video/SKILL.md)). |
 
 ---

--- a/README.zh.md
+++ b/README.zh.md
@@ -64,6 +64,9 @@ npx skills add modelstudioai/skills
 | 技能 | 说明 |
 |------|------|
 | [`bailian-docs-llm-wiki`](./skills/bailian-docs-llm-wiki/) | 引导 Agent 查阅仓库内置的**百炼文档库**：模型规格与定价、API/错误码、智能体/RAG/知识库、SDK 与多模态、计费等。从 `models/index.md` 和 `wiki/index.md` 开始逐层查阅。 |
+| [`bailian-model-recommend`](./skills/bailian-model-recommend/) | **模型选型与推荐**：根据场景或功能需求，从百炼模型库中推荐最合适的模型并附可直接运行的示例代码。命中"推荐 / 选哪个 / 对比"等意图时激活，内部读取 `bailian-docs-llm-wiki` 的 `models/` 数据。 |
+| [`financial-expert`](./skills/financial-expert/) | **金融数据分析**：基于 `bl mcp`（`market-cmapi00073529`），覆盖中国 A 股、基金、债券。支持选股 / 基金 / 基金经理筛选、财务数据（净利润 / 营收 / ROE）、宏观与行业时序（GDP / CPI）、券商研报、上市公司公告检索。 |
+| [`happyhorse-prompt-studio`](./skills/happyhorse-prompt-studio/) | **HappyHorse 1.0 视频提示词工作室**：用生动示例引导用户发现场景，再组装出 日/中/英 三语的成片级 Prompt。覆盖漫剧、角色 PV、漫画运动、虚拟偶像 MV 及自由创作场景。 |
 | [`spark-video`](./skills/spark-video/) | **端到端短片制作**：编剧 ↔ 导演（逐场景）→ 并行渲染 DAG → 逐 clip 审片 → 拼接。适合"帮我做一集短剧/产品广告"一句话出片。入口技能注册为 **`spark-video-episode`**（见 [`SKILL.md`](./skills/spark-video/SKILL.md)）。 |
 
 ---


### PR DESCRIPTION
## What

Add the three first-party skills that ship in this repo but were missing from the README first-party table:

- `bailian-model-recommend`
- `financial-expert`
- `happyhorse-prompt-studio`

## Why

The `skills/` directory contains 5 first-party skills, but the README only listed 2 (`bailian-docs-llm-wiki`, `spark-video`). This brings the table in sync with the actual contents.

Updated both `README.md` and `README.zh.md` to keep them consistent. Descriptions are distilled from each skill's `SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)